### PR TITLE
feat: apply prosemirror to wysiwyg editor

### DIFF
--- a/apps/editor/src/css/contents.css
+++ b/apps/editor/src/css/contents.css
@@ -30,8 +30,8 @@
   color: #222;
 }
 
-.tui-editor-contents > h1:first-of-type,
-.tui-editor-contents > div > div:first-of-type h1 {
+.tui-editor-contents h1:first-of-type,
+.tui-editor-contents div > div:first-of-type h1 {
   margin-top: 14px;
 }
 

--- a/apps/editor/src/js/convertor.js
+++ b/apps/editor/src/js/convertor.js
@@ -8,6 +8,10 @@ import { Parser, createRenderHTML } from '@toast-ui/toastmark';
 import { getHTMLRenderConvertors } from './htmlRenderConvertors';
 import domUtils from './utils/dom';
 
+// v3.0
+import { DOMParser } from 'prosemirror-model';
+import { convertMdNodeToDoc } from './convertor/toWysiwygModel';
+
 // This regular expression refere markdownIt.
 // https://github.com/markdown-it/markdown-it/blob/master/lib/common/html_re.js
 const attrName = '[a-zA-Z_:][a-zA-Z0-9:._-]*';
@@ -117,6 +121,23 @@ class Convertor {
     html = this.eventManager.emitReduce('convertorAfterMarkdownToHtmlConverted', html);
 
     return html;
+  }
+
+  /**
+   * @param {HTMLElement|ToastMark} content - content to convert to prosemirror model
+   * @param {Schema} schema - prosemirror schema instance
+   * @param {boolean} isDom - whether content is dom or not
+   */
+  toWysiwygModel(content, schema, isDom) {
+    let doc;
+
+    if (isDom) {
+      doc = DOMParser.fromSchema(schema).parse(content);
+    } else {
+      doc = convertMdNodeToDoc(schema, content);
+    }
+
+    return doc;
   }
 
   /**

--- a/apps/editor/src/js/convertor/nodeMap.js
+++ b/apps/editor/src/js/convertor/nodeMap.js
@@ -1,0 +1,90 @@
+export const nodeMap = {
+  // block
+  paragraph: { block: 'paragraph' },
+
+  heading: {
+    block: 'heading',
+    getAttrs: node => {
+      return { level: node.level };
+    }
+  },
+
+  codeBlock: {
+    block: 'codeBlock',
+    getAttrs: node => {
+      return { language: node.info || '' };
+    },
+    unclosedNode: true
+  },
+
+  bulletList: { block: 'bulletList' },
+
+  orderedList: {
+    block: 'orderedList',
+    getAttrs: node => {
+      return { order: node.start };
+    }
+  },
+
+  item: {
+    block: 'item',
+    getAttrs: node => {
+      const { task, checked } = node.listData;
+
+      return { task, checked };
+    }
+  },
+
+  blockQuote: { block: 'blockQuote' },
+
+  table: { block: 'table' },
+
+  tableHead: { block: 'tableHead' },
+
+  tableBody: { block: 'tableBody' },
+
+  tableRow: { block: 'tableRow' },
+
+  tableHeadCell: { block: 'tableHeadCell' },
+
+  tableBodyCell: { block: 'tableBodyCell' },
+
+  // block - empty element
+  thematicBreak: { node: 'thematicBreak' },
+
+  // inline - empty element
+  image: {
+    node: 'image',
+    getAttrs: node => {
+      const { destination, title, firstChild } = node;
+
+      return {
+        src: destination,
+        title: title || null,
+        alt: firstChild && firstChild.literal
+      };
+    },
+    skipChilren: true
+  },
+
+  // mark
+  strong: { mark: 'strong' },
+
+  emph: { mark: 'emph' },
+
+  strike: { mark: 'strike' },
+
+  link: {
+    mark: 'link',
+    getAttrs: node => {
+      const { destination, title } = node;
+
+      return {
+        href: destination,
+        title: title || null
+      };
+    }
+  },
+
+  code: { mark: 'code', unclosedNode: true }
+};

--- a/apps/editor/src/js/convertor/toWysiwygModel.js
+++ b/apps/editor/src/js/convertor/toWysiwygModel.js
@@ -1,4 +1,4 @@
-import MarkdownParseState from './wysiwygModelConvertorState';
+import WysiwygModelConvertorState from './wysiwygModelConvertorState';
 import { nodeMap } from './nodeMap';
 
 function getAttrs(spec, node) {
@@ -14,13 +14,6 @@ function getAttrs(spec, node) {
 
   return attributes;
 }
-function isUnclosedNode(spec, type) {
-  return spec.unclosedNode || type === 'code' || type === 'codeBlock';
-}
-
-function isSkipChildrenNode(spec, type) {
-  return spec.skipChilren || type === 'image';
-}
 
 function getTextWithoutTrailingNewline(str) {
   return str[str.length - 1] === '\n' ? str.slice(0, str.length - 1) : str;
@@ -35,7 +28,7 @@ function createNodeHandlers(schema, nodeTypes) {
     if (spec.block) {
       const nodeType = schema.nodeType(spec.block);
 
-      if (isUnclosedNode(spec, type)) {
+      if (spec.unclosedNode) {
         handlers[type] = (state, node) => {
           state.openNode(nodeType, getAttrs(spec, node));
           state.addText(getTextWithoutTrailingNewline(node.literal));
@@ -54,7 +47,7 @@ function createNodeHandlers(schema, nodeTypes) {
       const nodeType = schema.nodeType(spec.node);
 
       handlers[type] = (state, node, { entering, skipChildren }) => {
-        if (isSkipChildrenNode(spec, type) && entering) {
+        if (spec.skipChilren && entering) {
           skipChildren();
         }
 
@@ -63,7 +56,7 @@ function createNodeHandlers(schema, nodeTypes) {
     } else if (spec.mark) {
       const markType = schema.marks[spec.mark];
 
-      if (isUnclosedNode(spec, type)) {
+      if (spec.unclosedNode) {
         handlers[type] = (state, node) => {
           state.openMark(markType.create(getAttrs(spec, node)));
           state.addText(getTextWithoutTrailingNewline(node.literal));
@@ -90,7 +83,7 @@ function createNodeHandlers(schema, nodeTypes) {
 
 export function convertMdNodeToDoc(schema, mdNode) {
   const handlers = createNodeHandlers(schema, nodeMap);
-  const state = new MarkdownParseState(schema, handlers);
+  const state = new WysiwygModelConvertorState(schema, handlers);
 
   state.convertNodes(mdNode);
 

--- a/apps/editor/src/js/convertor/toWysiwygModel.js
+++ b/apps/editor/src/js/convertor/toWysiwygModel.js
@@ -1,0 +1,104 @@
+import MarkdownParseState from './wysiwygModelConvertorState';
+import { nodeMap } from './nodeMap';
+
+function getAttrs(spec, node) {
+  let attributes;
+
+  if (spec.getAttrs) {
+    attributes = spec.getAttrs(node);
+  } else if (spec.attrs instanceof Function) {
+    attributes = spec.attrs(node);
+  } else {
+    attributes = spec.attrs;
+  }
+
+  return attributes;
+}
+function isUnclosedNode(spec, type) {
+  return spec.unclosedNode || type === 'code' || type === 'codeBlock';
+}
+
+function isSkipChildrenNode(spec, type) {
+  return spec.skipChilren || type === 'image';
+}
+
+function getTextWithoutTrailingNewline(str) {
+  return str[str.length - 1] === '\n' ? str.slice(0, str.length - 1) : str;
+}
+
+function createNodeHandlers(schema, nodeTypes) {
+  const handlers = {};
+
+  Object.keys(nodeTypes).forEach(type => {
+    const spec = nodeTypes[type];
+
+    if (spec.block) {
+      const nodeType = schema.nodeType(spec.block);
+
+      if (isUnclosedNode(spec, type)) {
+        handlers[type] = (state, node) => {
+          state.openNode(nodeType, getAttrs(spec, node));
+          state.addText(getTextWithoutTrailingNewline(node.literal));
+          state.closeNode();
+        };
+      } else {
+        handlers[type] = (state, node, { entering }) => {
+          if (entering) {
+            state.openNode(nodeType, getAttrs(spec, node));
+          } else {
+            state.closeNode();
+          }
+        };
+      }
+    } else if (spec.node) {
+      const nodeType = schema.nodeType(spec.node);
+
+      handlers[type] = (state, node, { entering, skipChildren }) => {
+        if (isSkipChildrenNode(spec, type) && entering) {
+          skipChildren();
+        }
+
+        state.addNode(nodeType, getAttrs(spec, node));
+      };
+    } else if (spec.mark) {
+      const markType = schema.marks[spec.mark];
+
+      if (isUnclosedNode(spec, type)) {
+        handlers[type] = (state, node) => {
+          state.openMark(markType.create(getAttrs(spec, node)));
+          state.addText(getTextWithoutTrailingNewline(node.literal));
+          state.closeMark(markType);
+        };
+      } else {
+        handlers[type] = (state, node, { entering }) => {
+          if (entering) {
+            state.openMark(markType.create(getAttrs(spec, node)));
+          } else {
+            state.closeMark(markType);
+          }
+        };
+      }
+    }
+  });
+
+  handlers.text = (state, node) => state.addText(node.literal);
+  handlers.inline = (state, node) => state.convertNodes(node);
+  handlers.softbreak = handlers.softbreak || (state => state.addText('\n'));
+
+  return handlers;
+}
+
+export function convertMdNodeToDoc(schema, mdNode) {
+  const handlers = createNodeHandlers(schema, nodeMap);
+  const state = new MarkdownParseState(schema, handlers);
+
+  state.convertNodes(mdNode);
+
+  let doc;
+
+  do {
+    doc = state.closeNode();
+  } while (state.stack.length);
+
+  return doc;
+}

--- a/apps/editor/src/js/convertor/wysiwygModelConvertorState.js
+++ b/apps/editor/src/js/convertor/wysiwygModelConvertorState.js
@@ -1,0 +1,124 @@
+import { Mark } from 'prosemirror-model';
+
+function maybeMerge(a, b) {
+  if (a.isText && b.isText && Mark.sameSet(a.marks, b.marks)) {
+    return a.withText(a.text + b.text);
+  }
+
+  return false;
+}
+
+export default class WysiwygModelConvertorState {
+  constructor(schema, nodeHandlers) {
+    this.schema = schema;
+    this.stack = [{ type: schema.topNodeType, content: [] }];
+    this.marks = Mark.none;
+    this.nodeHandlers = nodeHandlers;
+  }
+
+  top() {
+    return this.stack[this.stack.length - 1];
+  }
+
+  push(elt) {
+    if (this.stack.length) {
+      this.top().content.push(elt);
+    }
+  }
+
+  addText(text) {
+    if (text) {
+      const nodes = this.top().content;
+      const last = nodes[nodes.length - 1];
+      const node = this.schema.text(text, this.marks);
+      const merged = last && maybeMerge(last, node);
+
+      if (merged) {
+        nodes[nodes.length - 1] = merged;
+      } else {
+        nodes.push(node);
+      }
+    }
+  }
+
+  openMark(mark) {
+    this.marks = mark.addToSet(this.marks);
+  }
+
+  closeMark(mark) {
+    this.marks = mark.removeFromSet(this.marks);
+  }
+
+  addNode(type, attrs, content) {
+    const node = type.createAndFill(attrs, content, this.marks);
+
+    if (node) {
+      this.push(node);
+
+      return node;
+    }
+
+    return null;
+  }
+
+  openNode(type, attrs) {
+    this.stack.push({ type, attrs, content: [] });
+  }
+
+  closeNode() {
+    if (this.marks.length) {
+      this.marks = Mark.none;
+    }
+
+    const { type, attrs, content } = this.stack.pop();
+
+    return this.addNode(type, attrs, content);
+  }
+
+  getNodeHandler(node) {
+    let { type } = node;
+
+    if (type === 'list') {
+      const { listData } = node;
+
+      type = `${listData.type}List`;
+    } else if (type === 'tableCell') {
+      const parentType = node.parent.parent && node.parent.parent.type;
+
+      if (parentType === 'tableHead' || parentType === 'tableBody') {
+        type = `${parentType}Cell`;
+      }
+    }
+
+    return this.nodeHandlers[type];
+  }
+
+  convertNodes(mdNode) {
+    const walker = mdNode.walker();
+    let event = walker.next();
+
+    while (event) {
+      const { node, entering } = event;
+      const handler = this.getNodeHandler(node);
+
+      let skipped = false;
+      const context = {
+        entering,
+        skipChildren: () => {
+          skipped = true;
+        }
+      };
+
+      if (handler) {
+        handler(this, node, context);
+      }
+
+      if (skipped) {
+        walker.resumeAt(node, false);
+        walker.next();
+      }
+
+      event = walker.next();
+    }
+  }
+}

--- a/apps/editor/src/js/editor.js
+++ b/apps/editor/src/js/editor.js
@@ -15,7 +15,6 @@ import { sendHostName, sanitizeLinkAttribute } from './utils/common';
 
 import MarkdownEditor from './markdownEditor';
 import MarkdownPreview from './mdPreview';
-import WysiwygEditor from './wysiwygEditor';
 import Layout from './layout';
 import EventManager from './eventManager';
 import CommandManager from './commandManager';
@@ -80,6 +79,9 @@ import wwOutdent from './wysiwygCommands/outdent';
 import wwTask from './wysiwygCommands/task';
 import wwCode from './wysiwygCommands/code';
 import wwCodeBlock from './wysiwygCommands/codeBlock';
+
+// v3.0
+import WysiwygEditor from './wysiwyg/editor';
 
 import { ToastMark } from '@toast-ui/toastmark';
 import { register } from './scroll/sync';
@@ -260,10 +262,7 @@ class ToastUIEditor {
       }
     );
 
-    this.wwEditor = WysiwygEditor.factory(this.layout.getWwEditorContainerEl(), this.eventManager, {
-      sanitizer,
-      linkAttribute
-    });
+    this.wwEditor = new WysiwygEditor(this.layout.getWwEditorContainerEl());
 
     this.toMarkOptions = {
       gfm: true,
@@ -673,7 +672,13 @@ class ToastUIEditor {
 
     if (this.isWysiwygMode()) {
       this.layout.switchToWYSIWYG();
-      this.wwEditor.setValue(this.convertor.toHTML(this.mdEditor.getValue()), !isWithoutFocus);
+
+      const mdNode = this.toastMark.getRootNode();
+      const schema = this.wwEditor.getSchema();
+      const wwModel = this.convertor.toWysiwygModel(mdNode, schema);
+
+      this.wwEditor.setValue(wwModel);
+
       this.eventManager.emit('changeModeToWysiwyg');
     } else {
       this.layout.switchToMarkdown();

--- a/apps/editor/src/js/index.js
+++ b/apps/editor/src/js/index.js
@@ -9,6 +9,9 @@ import '../css/contents.css';
 import '../css/preview-highlighting.css';
 import '../css/md-syntax-highlighting.css';
 
+// v3.0 prosemirror style
+import 'prosemirror-view/style/prosemirror.css';
+
 import './i18n/en-us';
 
 export default Editor;

--- a/apps/editor/src/js/wysiwyg/editor.js
+++ b/apps/editor/src/js/wysiwyg/editor.js
@@ -1,0 +1,61 @@
+import { EditorState, Plugin } from 'prosemirror-state';
+import { EditorView } from 'prosemirror-view';
+import { keymap } from 'prosemirror-keymap';
+import { baseKeymap } from 'prosemirror-commands';
+
+import { createGfmSchema } from './schema/gfm';
+
+const CONTENTS_CLASS_NAME = 'tui-editor-contents';
+
+const schema = createGfmSchema();
+const baseStates = {
+  schema,
+  plugins: [
+    keymap(baseKeymap),
+    new Plugin({
+      props: {
+        attributes: { class: CONTENTS_CLASS_NAME }
+      }
+    })
+  ]
+};
+
+export default class WysiwygEditor {
+  constructor(container) {
+    this.view = this.createEditorView(container);
+  }
+
+  createEditorView(container) {
+    const state = EditorState.create({ ...baseStates });
+
+    return new EditorView(container, { state });
+  }
+
+  setValue(doc) {
+    const addedStates = { doc };
+    const newState = EditorState.create({ ...baseStates, ...addedStates });
+
+    this.view.updateState(newState);
+  }
+
+  /**
+   * @TODO add logic to set min-eight value
+   */
+  setMinHeight() {}
+
+  /**
+   * @TODO change return value to prosemirror model
+   */
+  getValue() {
+    return '';
+  }
+
+  getSchema() {
+    return this.view.state.schema;
+  }
+
+  /**
+   * @TODO add logic to focus editor element
+   */
+  focus() {}
+}

--- a/apps/editor/src/js/wysiwyg/schema/basic.js
+++ b/apps/editor/src/js/wysiwyg/schema/basic.js
@@ -1,0 +1,229 @@
+import { Schema } from 'prosemirror-model';
+
+export const basicSchema = {
+  nodes: {
+    doc: {
+      content: 'block+'
+    },
+
+    // block
+    paragraph: {
+      content: 'inline*',
+      group: 'block',
+      parseDOM: [{ tag: 'p' }],
+      toDOM() {
+        return ['p', 0];
+      }
+    },
+
+    heading: {
+      attrs: { level: { default: 1 } },
+      content: 'inline*',
+      group: 'block',
+      defining: true,
+      parseDOM: [
+        { tag: 'h1', attrs: { level: 1 } },
+        { tag: 'h2', attrs: { level: 2 } },
+        { tag: 'h3', attrs: { level: 3 } },
+        { tag: 'h4', attrs: { level: 4 } },
+        { tag: 'h5', attrs: { level: 5 } },
+        { tag: 'h6', attrs: { level: 6 } }
+      ],
+      toDOM(node) {
+        return [`h${node.attrs.level}`, 0];
+      }
+    },
+
+    codeBlock: {
+      content: 'text*',
+      group: 'block',
+      attrs: {
+        class: { default: null },
+        language: { default: null }
+      },
+      code: true,
+      defining: true,
+      marks: '',
+      parseDOM: [
+        {
+          tag: 'pre',
+          preserveWhitespace: 'full',
+          getAttrs(dom) {
+            const className = dom.getAttribute('class');
+            const language = className.split('lang-');
+
+            return {
+              class: className,
+              language
+            };
+          }
+        }
+      ],
+      toDOM(node) {
+        return [
+          'pre',
+          { class: node.attrs.class || null },
+          ['code', { 'data-language': node.attrs.language || null }, 0]
+        ];
+      }
+    },
+
+    bulletList: {
+      content: 'item+',
+      group: 'block',
+      parseDOM: [
+        {
+          tag: 'ul'
+        }
+      ],
+      toDOM() {
+        return ['ul', 0];
+      }
+    },
+
+    orderedList: {
+      content: 'item+',
+      group: 'block',
+      attrs: { order: { default: 1 } },
+      parseDOM: [
+        {
+          tag: 'ol',
+          getAttrs(dom) {
+            const start = parseInt(dom.getAttribute('start'), 10);
+
+            return {
+              order: dom.hasAttribute('start') ? start : 1
+            };
+          }
+        }
+      ],
+      toDOM(node) {
+        return [
+          'ol',
+          {
+            start: node.attrs.order === 1 ? null : node.attrs.order
+          },
+          0
+        ];
+      }
+    },
+
+    item: {
+      content: '(paragraph | codeBlock | bulletList | orderedList)*',
+      defining: true,
+      parseDOM: [{ tag: 'li' }],
+      toDOM() {
+        return ['li', 0];
+      }
+    },
+
+    blockQuote: {
+      content: 'block+',
+      group: 'block',
+      parseDOM: [{ tag: 'blockquote' }],
+      toDOM() {
+        return ['blockquote', 0];
+      }
+    },
+
+    // block - empty element
+    thematicBreak: {
+      group: 'block',
+      parseDOM: [{ tag: 'hr' }],
+      toDOM() {
+        return ['div', ['hr']];
+      }
+    },
+
+    // inline
+    text: {
+      group: 'inline'
+    },
+
+    // inline - empty element
+    image: {
+      inline: true,
+      attrs: {
+        src: {},
+        title: { default: null },
+        alt: { default: null }
+      },
+      group: 'inline',
+      draggable: true,
+      parseDOM: [
+        {
+          tag: 'img[src]',
+          getAttrs(dom) {
+            return {
+              src: dom.getAttribute('src'),
+              title: dom.getAttribute('title'),
+              alt: dom.getAttribute('alt')
+            };
+          }
+        }
+      ],
+      toDOM(node) {
+        return ['img', node.attrs];
+      }
+    },
+
+    linebreak: {
+      inline: true,
+      group: 'inline',
+      selectable: false,
+      parseDOM: [{ tag: 'br' }],
+      toDOM() {
+        return ['br'];
+      }
+    }
+  },
+
+  marks: {
+    strong: {
+      parseDOM: [{ tag: 'b' }, { tag: 'strong' }],
+      toDOM() {
+        return ['strong'];
+      }
+    },
+
+    emph: {
+      parseDOM: [{ tag: 'i' }, { tag: 'em' }],
+      toDOM() {
+        return ['em'];
+      }
+    },
+
+    link: {
+      attrs: {
+        href: {},
+        title: { default: null }
+      },
+      inclusive: false,
+      parseDOM: [
+        {
+          tag: 'a[href]',
+          getAttrs(dom) {
+            return {
+              href: dom.getAttribute('href'),
+              title: dom.getAttribute('title') || null
+            };
+          }
+        }
+      ],
+      toDOM(node) {
+        return ['a', node.attrs];
+      }
+    },
+
+    code: {
+      parseDOM: [{ tag: 'code' }],
+      toDOM() {
+        return ['code'];
+      }
+    }
+  }
+};
+
+export function createBasicSchema() {
+  return new Schema(basicSchema);
+}

--- a/apps/editor/src/js/wysiwyg/schema/gfm.js
+++ b/apps/editor/src/js/wysiwyg/schema/gfm.js
@@ -1,0 +1,168 @@
+import { Schema } from 'prosemirror-model';
+import { basicSchema } from './basic';
+
+const gfmSchema = {
+  nodes: {
+    item: {
+      content: '(paragraph | codeBlock | bulletList | orderedList)*',
+      group: 'block',
+      attrs: {
+        class: { default: null },
+        task: { default: false },
+        checked: { default: false }
+      },
+      defining: true,
+      parseDOM: [
+        {
+          tag: 'li',
+          getAttrs(dom) {
+            return {
+              class: dom.getAttribute('class'),
+              task: dom.hasAttribute('data-task'),
+              checked: !!dom.getAttribute('data-task-checked')
+            };
+          }
+        }
+      ],
+      toDOM(node) {
+        if (!node.attrs.task) {
+          return ['li', 0];
+        }
+
+        const classNames = ['task-list-item'];
+
+        if (node.attrs.checked) {
+          classNames.push('checked');
+        }
+
+        return [
+          'li',
+          {
+            class: classNames.join(' '),
+            'data-task': node.attrs.task,
+            'data-task-checked': node.attrs.checked
+          },
+          0
+        ];
+      }
+    },
+
+    table: {
+      content: 'tableHead{1} tableBody+',
+      group: 'block',
+      attrs: {
+        rows: { default: 1 },
+        columns: { default: 1 }
+      },
+      parseDOM: [{ tag: 'table' }],
+      toDOM() {
+        return ['table', 0];
+      }
+    },
+
+    tableHead: {
+      content: 'tableRow{1}',
+      attr: {
+        colums: { default: 1 }
+      },
+      parseDOM: [
+        {
+          tag: 'thead',
+          getAttrs(dom) {
+            const row = dom.querySelector('tr');
+
+            if (row && !row.children.length) {
+              return false;
+            }
+
+            return {
+              columns: row.children.length
+            };
+          }
+        }
+      ],
+      toDOM() {
+        return ['thead', 0];
+      }
+    },
+
+    tableBody: {
+      content: 'tableRow+',
+      attr: {
+        rows: { default: 1 },
+        colums: { default: 1 }
+      },
+      parseDOM: [
+        {
+          tag: 'tbody',
+          getAttrs(dom) {
+            const rows = dom.querySelectorAll('tr');
+            const [row] = rows;
+
+            if (!row.children.length) {
+              return false;
+            }
+
+            return {
+              rows: rows.length,
+              columns: row.children.length
+            };
+          }
+        }
+      ],
+      toDOM() {
+        return ['tbody', 0];
+      }
+    },
+
+    tableRow: {
+      content: '(tableHeadCell | tableBodyCell)+',
+      attrs: { columns: { default: 1 } },
+      parseDOM: [
+        {
+          tag: 'tr',
+          getAttrs: dom => (dom.children.length ? { columns: dom.children.length } : false)
+        }
+      ],
+      toDOM() {
+        return ['tr', 0];
+      }
+    },
+
+    tableHeadCell: {
+      content: 'text*',
+      parseDOM: [{ tag: 'th' }],
+      toDOM() {
+        return ['th', 0];
+      }
+    },
+
+    tableBodyCell: {
+      content: 'text*',
+      parseDOM: [{ tag: 'td' }],
+      toDOM() {
+        return ['td', 0];
+      }
+    }
+  },
+
+  marks: {
+    strike: {
+      parseDOM: [{ tag: 's' }, { tag: 'strike' }],
+      toDOM() {
+        return ['strike'];
+      }
+    }
+  }
+};
+
+export function createGfmSchema() {
+  const { nodes: basicNodes, marks: basicMarks } = basicSchema;
+  const { nodes: gfmNodes, marks: gfmMarks } = gfmSchema;
+  const customSchema = {
+    nodes: { ...basicNodes, ...gfmNodes },
+    marks: { ...basicMarks, ...gfmMarks }
+  };
+
+  return new Schema(customSchema);
+}

--- a/apps/editor/test/demo/editor-prosemirror.html
+++ b/apps/editor/test/demo/editor-prosemirror.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html>
+  <head lang="en">
+    <meta charset="UTF-8" />
+    <title>Demo</title>
+    <!-- Editor's Dependencies -->
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.33.0/codemirror.css"
+    />
+    <!-- Editor -->
+    <link rel="stylesheet" href="../../dist/cdn/toastui-editor.css" />
+    <style type="text/css">
+      .ProseMirror {
+        height: 100%;
+        outline: none;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="editor"></div>
+    <!-- Editor Dependencies -->
+    <!-- Editor -->
+    <script src="../../dist/cdn/toastui-editor-all.js"></script>
+    <script class="code-js">
+      const content = [
+        '![image](https://uicdn.toast.com/toastui/img/tui-editor-bi.png)',
+        '',
+        '# Awesome Editor!',
+        '',
+        'It has been _released as opensource in 2018_ and has ~~continually~~ evolved to **receive 10k GitHub ⭐️ Stars**.',
+        '',
+        '## Create Instance',
+        '',
+        'You can create an instance with the following code and use `getHtml()` and `getMarkdown()` of the [Editor](https://github.com/nhn/tui.editor).',
+        '',
+        '```js',
+        'const editor = new Editor(options);',
+        '```',
+        '',
+        '> See the table below for default options',
+        '> > More API information can be found in the document',
+        '',
+        '| name | type | description |',
+        '| --- | --- | --- |',
+        '| el | `HTMLElement` | container element |',
+        '',
+        '## Features',
+        '',
+        '* CommonMark + GFM Specifications',
+        '   * Live Preview',
+        '   * Scroll Sync',
+        '   * Auto Indent',
+        '   * Syntax Highlight',
+        '        1. Markdown',
+        '        2. Preview',
+        '',
+        '## Support Wrappers',
+        '',
+        '> * Wrappers',
+        '>    1. [x] React',
+        '>    2. [x] Vue',
+        '>    3. [ ] Ember'
+      ].join('\n');
+
+      const editor = new toastui.Editor({
+        el: document.querySelector('#editor'),
+        previewStyle: 'vertical',
+        height: '400px',
+        initialValue: content
+      });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## 작업 내용

* [x] 위지윅 에디터를 프로즈미러로 변경 : 456929109619b8847c1d9e4e5a474ab25020da9b
* [x] 커스텀 스키마 추가 : 1689ac1c39ab8a05fdadb476ed5c5efb7e4e3e24
  * [x] 베이직
  * [x] gfm
* [x] ToastMark <-> 프로즈미러 도큐먼트 컨버터 개발 : 7205958fa3a4b380c49897cf5f680002b260ed9c
  * [x] 컨버팅 모듈 개발 ([`prosemirror-markdown`](https://github.com/ProseMirror/prosemirror-markdown/blob/master/src/from_markdown.js) 코어 모듈 가져와서 가공하여 사용)
  * [x] 노드 맵 작성

## 신규 추가 파일 구성

```
- root/
   |- wysiwyg/
   │   |- schema/
   |   |  |- basic.js
   |   |  |- gfm.js
   |   ㄴ editor.js
   |- convertor/
   │   |- wysiwygModelConvertorState.js
   │   |- nodeMap.js
   |   ㄴ toWysiwygModel.js
```

* `wysiwygModelConvertorState.js` : prosemirror 모델로 변환할 때 노드 상태를 관리하는 클래스 선언
* `nodeMap.js` : 컨버팅 시 노드마다 호출되는 핸들러 선언 객체 선언
* `toWysiwygModel.js` : markdown 노드 -> prosemirror 모델로 변경하는 컨버팅 함수 선언